### PR TITLE
LazyLoadingTreeNode ClassCastException fix

### DIFF
--- a/src/org/cakelab/blender/ui/tree/generic/LazyLoadingTreeNode.java
+++ b/src/org/cakelab/blender/ui/tree/generic/LazyLoadingTreeNode.java
@@ -16,23 +16,25 @@ public abstract class LazyLoadingTreeNode extends DefaultMutableTreeNode {
 		super(userObject);
 	}
 	
-	@SuppressWarnings("unchecked")
 	protected void lazyLoadChildren() {
-		if (!loaded) {
-            if (children == null) {
-                children = new Vector<MutableTreeNode>();
-            }
-            try {
-            	loadChildren((Vector<MutableTreeNode>)children);
-            	// make sure parent is set for all children
-            	for (Object n : children) {
-            		((MutableTreeNode)n).setParent(this);
-            	}
-    			loaded = true;
-            } catch (Throwable t) {
-            	// TODO: report error
-            	System.err.println(t);
-            }
+		if (!this.loaded) {
+			if (this.children == null) {
+				this.children = new Vector<>();
+			}
+			try {
+				Vector<MutableTreeNode> vectorChildren = new Vector<>();
+				this.loadChildren(vectorChildren);
+				// make sure parent is set for all children
+				for (MutableTreeNode n : vectorChildren) {
+					n.setParent(this);
+					this.children.add(n);
+				}
+				this.loaded = true;
+			}
+			catch (Throwable t) {
+				// TODO: report error
+				System.err.println(t);
+			}
 		}
 	}
 

--- a/src/org/cakelab/blender/ui/tree/generic/TreeModel.java
+++ b/src/org/cakelab/blender/ui/tree/generic/TreeModel.java
@@ -52,7 +52,7 @@ public class TreeModel extends DefaultTreeModel {
 
 	private TreeNode findFirst(TreeNode parent, Condition condition) {
 		@SuppressWarnings("unchecked")
-		Enumeration<TreeNode> children = parent.children();
+		Enumeration<TreeNode> children = (Enumeration<TreeNode>) parent.children();
 		while (children.hasMoreElements()) {
 			TreeNode child = children.nextElement();
 			if (condition.valid(child)) {


### PR DESCRIPTION
Had an issue where Vector\<MutableTreeNode\> cannot cast into Vector\<TreeNode\>, no matter how you slice or dice it, so I fixed it. This change also helped to get rid of the @SuppressedWarnings annotation.

My Eclipse 2022-06 just don't like the casting code. Had to improvise.
